### PR TITLE
:construction: add broken text to image action

### DIFF
--- a/creates/text_to_image.js
+++ b/creates/text_to_image.js
@@ -1,0 +1,63 @@
+const perform = async (z, bundle) => {
+    const { HfInference } = z.require('@huggingface/inference');
+    const hf = new HfInference(bundle.authData.key);
+
+    z.console.log("Making Prediction...");
+    z.console.log("Repo ID: " + bundle.inputData.repo_id);
+    z.console.log("Text: " + bundle.inputData.text);
+
+    // this returns a blob, but for some reason, Zapier tests fail, even thought
+    // I can see the image data in the console with `zapier test --debug`
+    // The error looks like its coming from huggingface.js, but this same code
+    // works fine in a standalone script. Hard coded for now so you can copy paste it
+    const resp = await hf.textToImage({
+        inputs: "a cat wearing a funny hat", // bundle.inputData.text,
+        model: "stabilityai/stable-diffusion-2" // bundle.inputData.repo_id
+    });
+
+    z.console.log("Got Prediction!");
+
+    // Need to return the image file, but since the above request fails, I'm hard coding this
+    return { url: "asdf" };
+  };
+
+module.exports = {
+    operation: {
+        inputFields: [
+        {
+            key: 'text',
+            label: 'Text',
+            type: 'text',
+            helpText: 'The prompt to use to generate an image',
+            required: true,
+            list: false,
+            altersDynamicFields: false,
+        },
+        {
+            key: 'repo_id',
+            label: 'Repo ID',
+            type: 'string',
+            helpText:
+            'The Repo ID for the model you wish to use. (Ex. `stabilityai/stable-diffusion-2`)',
+            required: true,
+            list: false,
+            altersDynamicFields: false,
+        },
+        ],
+        sample: {
+            id: 1,
+            filename: 'example.jpg',
+            file: 'SAMPLE FILE',
+          },
+        perform: perform,
+    },
+    key: 'text_to_image',
+    noun: 'Image',
+    display: {
+        label: 'Text to Image',
+        description:
+        'Use any compatible model from the Hugging Face to generate an image from a text prompt.',
+        hidden: false,
+        important: false,
+    },
+};

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const textGenerationCreate = require('./creates/text_generation.js');
 const summarizationCreate = require('./creates/summarization.js');
 const questionAnsweringCreate = require('./creates/question_answering.js');
 const zeroShotClassificationCreate = require('./creates/zero_shot_classification.js');
+const textToImageCreate = require('./creates/text_to_image.js');
 
 module.exports = {
   version: require('./package.json').version,
@@ -22,5 +23,6 @@ module.exports = {
     [summarizationCreate.key]: summarizationCreate,
     [questionAnsweringCreate.key]: questionAnsweringCreate,
     [zeroShotClassificationCreate.key]: zeroShotClassificationCreate,
+    [textToImageCreate.key]: textToImageCreate,
   },
 };

--- a/test/creates/text_to_image.js
+++ b/test/creates/text_to_image.js
@@ -1,0 +1,32 @@
+require('should');
+
+const zapier = require('zapier-platform-core');
+
+const App = require('../../index');
+const appTester = zapier.createAppTester(App);
+
+describe('Create - text_to_image', () => {
+  zapier.tools.env.inject();
+
+  it('should create an object', async () => {
+    const bundle = {
+      authData: {
+        key: process.env.KEY,
+        oauth_consumer_key: process.env.OAUTH_CONSUMER_KEY,
+        oauth_consumer_secret: process.env.OAUTH_CONSUMER_SECRET,
+        oauth_token: process.env.OAUTH_TOKEN,
+        oauth_token_secret: process.env.OAUTH_TOKEN_SECRET,
+      },
+      inputData: {
+        text: 'A cat with a funny hat',
+        repo_id: 'stabilityai/stable-diffusion-2',
+      },
+    };
+
+    const result = await appTester(
+      App.creates['text_to_image'].operation.perform,
+      bundle
+    );
+    result.should.not.be.an.Array();
+  });
+});


### PR DESCRIPTION
Trying to figure out how to run text to image from `huggingface.js`...the call here fails, but I think it has to do with timeout or something in zapier? Not sure. Left some notes in `creates/text_to_image.js`.